### PR TITLE
Change fallback gateway to Cloudflare IPFS gateway

### DIFF
--- a/javascripts/player.js
+++ b/javascripts/player.js
@@ -1,5 +1,5 @@
 gateways = [
-    "https://ipfs.io"
+    "https://cloudflare-ipfs.com"
 ]
 shortTermGw = "https://video.dtube.top"
 player = null


### PR DESCRIPTION
Cloudflare's gateway loads videos faster than ipfs.io gateway