### PR TITLE
Add gateway switcher on embed player

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         <script src="./javascripts/branding.js"></script>
         <script src="./javascripts/persistvolume.js"></script>
         <script src="./javascripts/resolutionswitcher.js"></script>
+        <script src="./javascripts/ipfsgatewayswitcher.js"></script>
         <script src="./javascripts/settingsmenubuttons.js"></script>
         <script src="./javascripts/settingsmenuitem.js"></script>
         <script src="./javascripts/hotkeys.js"></script>

--- a/javascripts/ipfsgatewayswitcher.js
+++ b/javascripts/ipfsgatewayswitcher.js
@@ -28,7 +28,7 @@
             }
         })
         GatewayMenuItem.prototype.handleClick = function(event) {
-            MenuItem.prototype.handleClick.call(this, event);
+            // MenuItem.prototype.handleClick.call(this, event);
 
             // Update source in resolution switcher plugin with selected gateway
             let newgw = event.target.innerText.replace(', selected','')
@@ -41,11 +41,9 @@
             }
 
             console.log('New sources',sourcesToChange)
+            console.log('Gateways changed to ' + event.target.innerText)
+            document.getElementsByClassName('vjs-settings-sub-menu-value')[document.getElementsByClassName('vjs-settings-sub-menu-value').length - 1].innerHTML = newgw
             player.updateSrc(sourcesToChange)
-
-            player.on('resolutionchange',() => {
-                console.log('Gateways changed to ' + event.target.innerText)
-            })
         };
         
         MenuItem.registerComponent('GatewayMenuItem', GatewayMenuItem);

--- a/javascripts/ipfsgatewayswitcher.js
+++ b/javascripts/ipfsgatewayswitcher.js
@@ -1,0 +1,241 @@
+/*! videojs-resolution-switcher - 2015-7-26
+ * Copyright (c) 2016 Kasper Moskwiak
+ * Modified by Pierre Kraft and Derk-Jan Hartman
+ * Licensed under the Apache-2.0 license. 
+ * https://github.com/kmoskwiak/videojs-resolution-switcher */
+
+(function() {
+    'use strict';
+    var videojs = null;
+    if (typeof window.videojs === 'undefined' && typeof require === 'function') {
+        videojs = require('video.js');
+    } else {
+        videojs = window.videojs;
+    }
+
+    (function(window, videojs) {
+        var IPFSGatewaySwitcher,
+            defaults = {
+                ui: true
+            };
+        const Component = videojs.getComponent('Component');
+        var MenuItem = videojs.getComponent('MenuItem');
+        var GatewayMenuItem = videojs.extend(MenuItem, {
+            constructor: function(player, options) {
+                options.selectable = true;
+                MenuItem.call(this, player, options);
+                this.src = options.src;
+
+                player.on('resolutionchange', videojs.bind(this, this.update));
+            }
+        });
+        GatewayMenuItem.prototype.handleClick = function(event) {
+            MenuItem.prototype.handleClick.call(this, event);
+            this.player_.currentResolution(this.options_.label);
+        };
+        GatewayMenuItem.prototype.update = function() {
+            var selection = this.player_.currentResolution();
+            this.selected(this.options_.label === selection.label);
+        };
+        MenuItem.registerComponent('GatewayMenuItem', GatewayMenuItem);
+
+        var MenuButton = videojs.getComponent('MenuButton');
+        var GatewaySwitcherMenuButton = videojs.extend(MenuButton, {
+            constructor: function(player, options) {
+                this.label = document.createElement('span');
+                options.label = 'Gateway';
+                MenuButton.call(this, player, options);
+                this.el().setAttribute('aria-label', 'Gateway');
+                this.controlText('Gateway');
+                this.controlText_ = 'Gateway'
+                this.addClass('vjs-resolution-switcher')
+
+                videojs.dom.addClass(this.label, 'vjs-resolution-button-label');
+
+                this.label.addEventListener("click", function() {
+                    var cur = player.currentResolutionState.label
+                    var i = 1;
+                    while (cur != player.currentSources[i - 1].label)
+                        i++
+                        if (i == player.currentSources.length)
+                            i = 0
+                    player.currentResolution(player.currentSources[i].label)
+                });
+                this.el().appendChild(this.label);
+
+                player.on('updateSources', videojs.bind(this, this.update));
+                player.on('resolutionchange', videojs.bind(this, this.update));
+            }
+        });
+        GatewaySwitcherMenuButton.prototype.createItems = function() {
+            let menuItems = [];
+
+            for (let i = 0; i < window.gateways.length; i++) {
+                menuItems.push(new GatewayMenuItem(
+                    this.player_, {
+                        label: window.gateways[i],
+                        // src: gateways[i] + '/ipfs/QmeMrTDkJhikJkqb2bRiS2uhBGJCmq67BPLbm4Tjvibopq',
+                        selected: window.gateways[i] === (this.currentSelection ? this.currentSelection.label : false)
+                    }
+                ))
+            }
+
+            return menuItems;
+        };
+        GatewaySwitcherMenuButton.prototype.update = function() {
+            this.sources = this.player_.getGroupedSrc();
+            this.currentSelection = this.player_.currentResolution();
+            this.label.innerHTML = this.currentSelection ? this.currentSelection.label : '';
+            return MenuButton.prototype.update.call(this);
+        };
+        GatewaySwitcherMenuButton.prototype.buildCSSClass = function() {
+            return MenuButton.prototype.buildCSSClass.call(this) + ' vjs-resolution-button';
+        };
+        MenuButton.registerComponent('GatewaySwitcherMenuButton', GatewaySwitcherMenuButton);
+
+        IPFSGatewaySwitcher = function(options) {
+            var settings = videojs.mergeOptions(defaults, options),
+                player = this,
+                groupedSrc = {},
+                currentSources = {},
+                currentResolutionState = {};
+
+            player.updateSrc = function(src) {
+                if (!src) { return player.src(); }
+
+                src = src.filter(function(source) {
+                    try {
+                        return (player.canPlayType(source.type) !== '');
+                    } catch (e) {
+                        return true;
+                    }
+                });
+                this.currentSources = src.sort(compareResolutions);
+                this.groupedSrc = bucketSources(this.currentSources);
+                var chosen = chooseSrc(this.groupedSrc, this.currentSources);
+                this.currentResolutionState = {
+                    label: chosen.label,
+                    sources: chosen.sources
+                };
+                chosen.sources = []
+                for (let i = 0; i < this.currentSources.length; i++) {
+                    if (this.currentSources[i].label == chosen.label)
+                        chosen.sources.push(this.currentSources[i])
+                }
+
+                player.trigger('updateSources');
+                player.setSourcesSanitized(chosen.sources, chosen.label);
+                player.trigger('resolutionchange');
+                return player;
+            };
+
+            player.currentResolution = function(label, customSourcePicker) {
+                if (label == null) { return this.currentResolutionState; }
+
+                if (!this.groupedSrc || !this.groupedSrc.label || !this.groupedSrc.label[label]) {
+                    return;
+                }
+                var sources = this.groupedSrc.label[label];
+                var currentTime = player.currentTime();
+                var isPaused = player.paused();
+
+                if (!isPaused && this.player_.options_.bigPlayButton) {
+                    this.player_.bigPlayButton.hide();
+                }
+
+                var handleSeekEvent = 'loadeddata';
+                if (this.player_.preload() === 'none') {
+                    handleSeekEvent = 'timeupdate';
+                }
+                player
+                    .setSourcesSanitized(sources, label, customSourcePicker || settings.customSourcePicker)
+                    .one(handleSeekEvent, function() {
+                        player.currentTime(currentTime);
+                        player.handleTechSeeked_();
+                        if (!isPaused) {
+                            player.play();
+                        }
+                        player.trigger('resolutionchange');
+                    });
+                return player;
+            };
+
+            player.getGroupedSrc = function() {
+                return this.groupedSrc;
+            };
+
+            player.setSourcesSanitized = function(sources, label, customSourcePicker) {
+                this.currentResolutionState = {
+                    label: label,
+                    sources: sources
+                };
+                if (typeof customSourcePicker === 'function') {
+                    return customSourcePicker(player, sources, label);
+                }
+                player.src(sources.map(function(src) {
+                    return { src: src.src, type: src.type, res: src.res };
+                }));
+                return player;
+            };
+
+            function compareResolutions(a, b) {
+                if (!a.res || !b.res) { return 0; }
+                return (+b.res) - (+a.res);
+            }
+
+            function bucketSources(src) {
+                var resolutions = {
+                    label: {},
+                    res: {},
+                    type: {}
+                };
+                src.map(function(source) {
+                    initResolutionKey(resolutions, 'label', source);
+                    initResolutionKey(resolutions, 'res', source);
+                    initResolutionKey(resolutions, 'type', source);
+
+                    appendSourceToKey(resolutions, 'label', source);
+                    appendSourceToKey(resolutions, 'res', source);
+                    appendSourceToKey(resolutions, 'type', source);
+                });
+                return resolutions;
+            }
+
+            function initResolutionKey(resolutions, key, source) {
+                if (resolutions[key][source[key]] == null) {
+                    resolutions[key][source[key]] = [];
+                }
+            }
+
+            function appendSourceToKey(resolutions, key, source) {
+                resolutions[key][source[key]].push(source);
+            }
+
+            function chooseSrc(groupedSrc, src) {
+                var obj = {
+                    res: settings['default'],
+                    label: settings['default'],
+                    sources: groupedSrc.res[settings['default']]
+                }
+                return obj;
+            }
+
+
+            player.ready(function() {
+                if (settings.ui) {
+                    var menuButton = new GatewaySwitcherMenuButton(player, settings);
+                    player.controlBar.resolutionSwitcher = player.controlBar.el_.insertBefore(menuButton.el_, player.controlBar.getChild('fullscreenToggle').el_);
+                    player.controlBar.resolutionSwitcher.dispose = function() {
+                        this.parentNode.removeChild(this);
+                    };
+                }
+                if (player.options_.sources.length > 1) {
+                    player.updateSrc(player.options_.sources);
+                }
+            });
+
+        };
+
+        videojs.registerPlugin('IPFSGatewaySwitcher', IPFSGatewaySwitcher);
+    })(window, videojs);
+})();

--- a/javascripts/ipfsgatewayswitcher.js
+++ b/javascripts/ipfsgatewayswitcher.js
@@ -1,8 +1,7 @@
-/*! videojs-resolution-switcher - 2015-7-26
- * Copyright (c) 2016 Kasper Moskwiak
- * Modified by Pierre Kraft and Derk-Jan Hartman
- * Licensed under the Apache-2.0 license. 
- * https://github.com/kmoskwiak/videojs-resolution-switcher */
+/*
+// Modified by techcoderx from resolutionswitcher.js
+// https://github.com/dtube/embed/blob/master/javascripts/resolutionswitcher.js
+*/
 
 (function() {
     'use strict';
@@ -28,8 +27,6 @@
             }
         })
         GatewayMenuItem.prototype.handleClick = function(event) {
-            // MenuItem.prototype.handleClick.call(this, event);
-
             // Update source in resolution switcher plugin with selected gateway
             let newgw = event.target.innerText.replace(', selected','')
             let sourcesToChange = player.options_.sources
@@ -85,10 +82,6 @@
         IPFSGatewaySwitcher = function(options) {
             let settings = videojs.mergeOptions(defaults, options),
                 player = this
-
-            console.log('Gateway switcher settings', settings)
-            console.log(window)
-            console.log(this)
 
             player.ready(function() {
                 if (settings.ui) {

--- a/javascripts/ipfsgatewayswitcher.js
+++ b/javascripts/ipfsgatewayswitcher.js
@@ -1,7 +1,5 @@
-/*
 // Modified by techcoderx from resolutionswitcher.js
 // https://github.com/dtube/embed/blob/master/javascripts/resolutionswitcher.js
-*/
 
 (function() {
     'use strict';
@@ -38,10 +36,10 @@
             }
 
             console.log('New sources',sourcesToChange)
-            console.log('Gateways changed to ' + event.target.innerText)
+            console.log('Gateways changed to ' + newgw)
             document.getElementsByClassName('vjs-settings-sub-menu-value')[document.getElementsByClassName('vjs-settings-sub-menu-value').length - 1].innerHTML = newgw
             player.updateSrc(sourcesToChange)
-        };
+        }
         
         MenuItem.registerComponent('GatewayMenuItem', GatewayMenuItem);
 
@@ -62,7 +60,6 @@
         });
         GatewaySwitcherMenuButton.prototype.createItems = function() {
             let menuItems = [];
-
             for (let i = 0; i < window.gateways.length; i++) {
                 menuItems.push(new GatewayMenuItem(
                     this.player_, {
@@ -71,12 +68,13 @@
                 ))
             }
 
-            return menuItems;
-        };
+            return menuItems
+        }
         
         GatewaySwitcherMenuButton.prototype.buildCSSClass = function() {
             return MenuButton.prototype.buildCSSClass.call(this) + ' vjs-resolution-button';
-        };
+        }
+
         MenuButton.registerComponent('GatewaySwitcherMenuButton', GatewaySwitcherMenuButton);
 
         IPFSGatewaySwitcher = function(options) {
@@ -89,12 +87,11 @@
                     player.controlBar.gatewaySwitcher = player.controlBar.el_.insertBefore(menuButton.el_, player.controlBar.getChild('fullscreenToggle').el_)
                     player.controlBar.gatewaySwitcher.dispose = function() {
                         this.parentNode.removeChild(this)
-                    };
+                    }
                 }
             })
+        }
 
-        };
-
-        videojs.registerPlugin('IPFSGatewaySwitcher', IPFSGatewaySwitcher);
+        videojs.registerPlugin('IPFSGatewaySwitcher', IPFSGatewaySwitcher)
     })(window, videojs);
 })();

--- a/javascripts/ipfsgatewayswitcher.js
+++ b/javascripts/ipfsgatewayswitcher.js
@@ -25,18 +25,29 @@
                 options.selectable = true;
                 MenuItem.call(this, player, options);
                 this.src = options.src;
-
-                player.on('resolutionchange', videojs.bind(this, this.update));
             }
-        });
+        })
         GatewayMenuItem.prototype.handleClick = function(event) {
             MenuItem.prototype.handleClick.call(this, event);
-            this.player_.currentResolution(this.options_.label);
+
+            // Update source in resolution switcher plugin with selected gateway
+            let newgw = event.target.innerText.replace(', selected','')
+            let sourcesToChange = player.options_.sources
+
+            console.log(newgw)
+
+            for (let i = 0; i < sourcesToChange.length; i++) {
+                sourcesToChange[i].src = newgw + '/ipfs/' + sourcesToChange[i].hash
+            }
+
+            console.log('New sources',sourcesToChange)
+            player.updateSrc(sourcesToChange)
+
+            player.on('resolutionchange',() => {
+                console.log('Gateways changed to ' + event.target.innerText)
+            })
         };
-        GatewayMenuItem.prototype.update = function() {
-            var selection = this.player_.currentResolution();
-            this.selected(this.options_.label === selection.label);
-        };
+        
         MenuItem.registerComponent('GatewayMenuItem', GatewayMenuItem);
 
         var MenuButton = videojs.getComponent('MenuButton');
@@ -51,20 +62,7 @@
                 this.addClass('vjs-resolution-switcher')
 
                 videojs.dom.addClass(this.label, 'vjs-resolution-button-label');
-
-                this.label.addEventListener("click", function() {
-                    var cur = player.currentResolutionState.label
-                    var i = 1;
-                    while (cur != player.currentSources[i - 1].label)
-                        i++
-                        if (i == player.currentSources.length)
-                            i = 0
-                    player.currentResolution(player.currentSources[i].label)
-                });
                 this.el().appendChild(this.label);
-
-                player.on('updateSources', videojs.bind(this, this.update));
-                player.on('resolutionchange', videojs.bind(this, this.update));
             }
         });
         GatewaySwitcherMenuButton.prototype.createItems = function() {
@@ -73,166 +71,36 @@
             for (let i = 0; i < window.gateways.length; i++) {
                 menuItems.push(new GatewayMenuItem(
                     this.player_, {
-                        label: window.gateways[i],
-                        // src: gateways[i] + '/ipfs/QmeMrTDkJhikJkqb2bRiS2uhBGJCmq67BPLbm4Tjvibopq',
-                        selected: window.gateways[i] === (this.currentSelection ? this.currentSelection.label : false)
+                        label: window.gateways[i]
                     }
                 ))
             }
 
             return menuItems;
         };
-        GatewaySwitcherMenuButton.prototype.update = function() {
-            this.sources = this.player_.getGroupedSrc();
-            this.currentSelection = this.player_.currentResolution();
-            this.label.innerHTML = this.currentSelection ? this.currentSelection.label : '';
-            return MenuButton.prototype.update.call(this);
-        };
+        
         GatewaySwitcherMenuButton.prototype.buildCSSClass = function() {
             return MenuButton.prototype.buildCSSClass.call(this) + ' vjs-resolution-button';
         };
         MenuButton.registerComponent('GatewaySwitcherMenuButton', GatewaySwitcherMenuButton);
 
         IPFSGatewaySwitcher = function(options) {
-            var settings = videojs.mergeOptions(defaults, options),
-                player = this,
-                groupedSrc = {},
-                currentSources = {},
-                currentResolutionState = {};
+            let settings = videojs.mergeOptions(defaults, options),
+                player = this
 
-            player.updateSrc = function(src) {
-                if (!src) { return player.src(); }
-
-                src = src.filter(function(source) {
-                    try {
-                        return (player.canPlayType(source.type) !== '');
-                    } catch (e) {
-                        return true;
-                    }
-                });
-                this.currentSources = src.sort(compareResolutions);
-                this.groupedSrc = bucketSources(this.currentSources);
-                var chosen = chooseSrc(this.groupedSrc, this.currentSources);
-                this.currentResolutionState = {
-                    label: chosen.label,
-                    sources: chosen.sources
-                };
-                chosen.sources = []
-                for (let i = 0; i < this.currentSources.length; i++) {
-                    if (this.currentSources[i].label == chosen.label)
-                        chosen.sources.push(this.currentSources[i])
-                }
-
-                player.trigger('updateSources');
-                player.setSourcesSanitized(chosen.sources, chosen.label);
-                player.trigger('resolutionchange');
-                return player;
-            };
-
-            player.currentResolution = function(label, customSourcePicker) {
-                if (label == null) { return this.currentResolutionState; }
-
-                if (!this.groupedSrc || !this.groupedSrc.label || !this.groupedSrc.label[label]) {
-                    return;
-                }
-                var sources = this.groupedSrc.label[label];
-                var currentTime = player.currentTime();
-                var isPaused = player.paused();
-
-                if (!isPaused && this.player_.options_.bigPlayButton) {
-                    this.player_.bigPlayButton.hide();
-                }
-
-                var handleSeekEvent = 'loadeddata';
-                if (this.player_.preload() === 'none') {
-                    handleSeekEvent = 'timeupdate';
-                }
-                player
-                    .setSourcesSanitized(sources, label, customSourcePicker || settings.customSourcePicker)
-                    .one(handleSeekEvent, function() {
-                        player.currentTime(currentTime);
-                        player.handleTechSeeked_();
-                        if (!isPaused) {
-                            player.play();
-                        }
-                        player.trigger('resolutionchange');
-                    });
-                return player;
-            };
-
-            player.getGroupedSrc = function() {
-                return this.groupedSrc;
-            };
-
-            player.setSourcesSanitized = function(sources, label, customSourcePicker) {
-                this.currentResolutionState = {
-                    label: label,
-                    sources: sources
-                };
-                if (typeof customSourcePicker === 'function') {
-                    return customSourcePicker(player, sources, label);
-                }
-                player.src(sources.map(function(src) {
-                    return { src: src.src, type: src.type, res: src.res };
-                }));
-                return player;
-            };
-
-            function compareResolutions(a, b) {
-                if (!a.res || !b.res) { return 0; }
-                return (+b.res) - (+a.res);
-            }
-
-            function bucketSources(src) {
-                var resolutions = {
-                    label: {},
-                    res: {},
-                    type: {}
-                };
-                src.map(function(source) {
-                    initResolutionKey(resolutions, 'label', source);
-                    initResolutionKey(resolutions, 'res', source);
-                    initResolutionKey(resolutions, 'type', source);
-
-                    appendSourceToKey(resolutions, 'label', source);
-                    appendSourceToKey(resolutions, 'res', source);
-                    appendSourceToKey(resolutions, 'type', source);
-                });
-                return resolutions;
-            }
-
-            function initResolutionKey(resolutions, key, source) {
-                if (resolutions[key][source[key]] == null) {
-                    resolutions[key][source[key]] = [];
-                }
-            }
-
-            function appendSourceToKey(resolutions, key, source) {
-                resolutions[key][source[key]].push(source);
-            }
-
-            function chooseSrc(groupedSrc, src) {
-                var obj = {
-                    res: settings['default'],
-                    label: settings['default'],
-                    sources: groupedSrc.res[settings['default']]
-                }
-                return obj;
-            }
-
+            console.log('Gateway switcher settings', settings)
+            console.log(window)
+            console.log(this)
 
             player.ready(function() {
                 if (settings.ui) {
-                    var menuButton = new GatewaySwitcherMenuButton(player, settings);
-                    player.controlBar.resolutionSwitcher = player.controlBar.el_.insertBefore(menuButton.el_, player.controlBar.getChild('fullscreenToggle').el_);
-                    player.controlBar.resolutionSwitcher.dispose = function() {
-                        this.parentNode.removeChild(this);
+                    let menuButton = new GatewaySwitcherMenuButton(player, settings)
+                    player.controlBar.gatewaySwitcher = player.controlBar.el_.insertBefore(menuButton.el_, player.controlBar.getChild('fullscreenToggle').el_)
+                    player.controlBar.gatewaySwitcher.dispose = function() {
+                        this.parentNode.removeChild(this)
                     };
                 }
-                if (player.options_.sources.length > 1) {
-                    player.updateSrc(player.options_.sources);
-                }
-            });
+            })
 
         };
 

--- a/javascripts/player.js
+++ b/javascripts/player.js
@@ -1,6 +1,8 @@
 gateways = [
     "https://video.dtube.top",
     "https://video.oneloveipfs.com",
+    "https://ipfsgateway.makingblocks.xyz",
+    "https://ipfs.busy.org",
     "https://ipfs.io",
     "https://ipfs.infura.io",
     "https://gateway.pinata.cloud",
@@ -121,9 +123,9 @@ function handleVideo(video) {
                 if (video.ipfs && video.ipfs.snaphash) snapHash = video.ipfs.snaphash
 
                 var spriteHash = ''
-                if (video.info && video.info.spriteHash) spriteHash = video.info.spriteHash
-                if (video.content && video.content.spriteHash) spriteHash = video.content.spriteHash
-                if (video.ipfs && video.ipfs.spriteHash) spriteHash = video.ipfs.spriteHash
+                if (video.info && video.info.spritehash) spriteHash = video.info.spritehash
+                if (video.content && video.content.spritehash) spriteHash = video.content.spritehash
+                if (video.ipfs && video.ipfs.spritehash) spriteHash = video.ipfs.spritehash
 
                 var duration = 0
                 if (video.info && video.info.duration) duration = video.info.duration
@@ -273,6 +275,10 @@ function createPlayer(posterHash, autoplay, branding, qualities, sprite, duratio
 
 
     videojs('player').ready(function() {
+        let loadedVidUrl = player.currentSources[0].src
+        let loadedGateway = loadedVidUrl.split('/ipfs/')[0]
+        document.getElementsByClassName('vjs-settings-sub-menu-value')[document.getElementsByClassName('vjs-settings-sub-menu-value').length - 1].innerHTML = loadedGateway
+        console.log(document.getElementsByClassName('vjs-settings-sub-menu-value'))
         this.hotkeys({
             seekStep: 5,
             enableModifiersForNumbers: false

--- a/javascripts/player.js
+++ b/javascripts/player.js
@@ -10,8 +10,8 @@ gateways = [
     "https://ipfs.eternum.io"
 ]
 steemAPI = [
-    "https://techcoderx.com",
     "https://api.steemit.com/",
+    "https://techcoderx.com",
     "https://steemd.minnowsupportproject.org/",
     "https://anyx.io/",
     "https://steemd.privex.io",

--- a/javascripts/player.js
+++ b/javascripts/player.js
@@ -2,6 +2,7 @@ gateways = [
     "https://video.dtube.top",
     "https://video.oneloveipfs.com",
     "https://ipfs.busy.org",
+    "https://ipfsgateway.makingblocks.xyz",
     "https://ipfs.io",
     "https://ipfs.infura.io",
     "https://gateway.temporal.cloud",

--- a/javascripts/player.js
+++ b/javascripts/player.js
@@ -1,7 +1,6 @@
 gateways = [
     "https://video.dtube.top",
     "https://video.oneloveipfs.com",
-    "https://ipfsgateway.makingblocks.xyz",
     "https://ipfs.busy.org",
     "https://ipfs.io",
     "https://ipfs.infura.io",
@@ -273,12 +272,11 @@ function createPlayer(posterHash, autoplay, branding, qualities, sprite, duratio
         player.thumbnails(listThumbnails);
     }
 
-
     videojs('player').ready(function() {
-        let loadedVidUrl = player.currentSources[0].src
+        let loadedVidUrl = player.options_.sources[0].src
         let loadedGateway = loadedVidUrl.split('/ipfs/')[0]
         document.getElementsByClassName('vjs-settings-sub-menu-value')[document.getElementsByClassName('vjs-settings-sub-menu-value').length - 1].innerHTML = loadedGateway
-        console.log(document.getElementsByClassName('vjs-settings-sub-menu-value'))
+        
         this.hotkeys({
             seekStep: 5,
             enableModifiersForNumbers: false

--- a/javascripts/player.js
+++ b/javascripts/player.js
@@ -104,6 +104,7 @@ function handleVideo(video) {
     switch (provider) {
         case "IPFS":
             var qualities = generateQualities(video)
+            if (video.ipfs && video.ipfs.gateway) shortTermGw = 'https://' + video.ipfs.gateway
             findInShortTerm(qualities[0].hash, function(isAvail) {
                 addQualitiesSource(qualities, (isAvail ? shortTermGw : gateways[0]))
         

--- a/javascripts/player.js
+++ b/javascripts/player.js
@@ -1,11 +1,18 @@
 gateways = [
+    "https://video.dtube.top",
+    "https://video.oneloveipfs.com",
     "https://ipfs.io",
-    "https://video.dtube.network"
+    "https://ipfs.infura.io",
+    "https://gateway.pinata.cloud",
+    "https://ipfs.eternum.io"
 ]
 steemAPI = [
+    "https://techcoderx.com",
     "https://api.steemit.com/",
     "https://steemd.minnowsupportproject.org/",
     "https://anyx.io/",
+    "https://steemd.privex.io",
+    "https://api.steem.house"
 ]
 avalonAPI = 'https://avalon.d.tube'
 shortTermGw = "https://video.dtube.top"
@@ -197,6 +204,7 @@ function createPlayer(posterHash, autoplay, branding, qualities, sprite, duratio
     if (subtitles)
         menuEntries.push('SubtitlesButton')
     menuEntries.push('ResolutionMenuButton')
+    menuEntries.push('GatewaySwitcherMenuButton')
 
 
     var defaultQuality = qualities[0].label

--- a/javascripts/player.js
+++ b/javascripts/player.js
@@ -199,6 +199,7 @@ function createPlayer(posterHash, autoplay, branding, qualities, sprite, duratio
 
     var video = document.body.appendChild(c);
 
+    // Setting menu items
     var menuEntries = []
     menuEntries.push('PlaybackRateMenuButton')
     if (subtitles)
@@ -242,8 +243,10 @@ function createPlayer(posterHash, autoplay, branding, qualities, sprite, duratio
             persistvolume: {
                 namespace: 'dtube'
             },
+            IPFSGatewaySwitcher: {},
             videoJsResolutionSwitcher: {
-                default: defaultQuality
+                default: defaultQuality,
+                dynamicLabel: true
             },
             statistics: {
 

--- a/javascripts/player.js
+++ b/javascripts/player.js
@@ -4,6 +4,7 @@ gateways = [
     "https://ipfs.busy.org",
     "https://ipfs.io",
     "https://ipfs.infura.io",
+    "https://gateway.temporal.cloud",
     "https://gateway.pinata.cloud",
     "https://ipfs.eternum.io"
 ]

--- a/player.css
+++ b/player.css
@@ -211,12 +211,13 @@
     position: fixed;
     right: 10px;
     bottom: 50px;
-    width: 200px;
+    width: auto;
     margin-right: 0px;
     padding: 5px;
     border-top: 2px red solid!important;
     border-radius: 5px;
     min-height: 84px;
+    min-width: 200px;
 }
 
 .video-js .vjs-menu-button-popup .vjs-menu .vjs-menu-item,
@@ -764,7 +765,7 @@ a:-webkit-any-link {
 .vjs-settings-sub-menu-value,
 .vjs-settings-sub-menu-title {
     display: inline-block;
-    padding: 0 5px;
+    padding: 0 4px;
 }
 
 
@@ -789,7 +790,7 @@ li {
 }
 
 .vjs-settings-sub-menu-title {
-    width: 8em;
+    width: auto;
     text-transform: initial;
 }
 


### PR DESCRIPTION
As [requested](https://github.com/dtube/dtube/blob/master/client/views/topbar/settingsdropdown/settingsdropdown.html#L31-L49) that the gateway switcher to be in the embed player.

In addition, it is possible to define a custom gateway where a video should be first loaded from by defining the gateway domain under `json.ipfs.gateway` ([example here](https://avalon.d.tube/content/techcoderx/QmUjdAVxFsRS2M6ZJSbo2vfoABKhCEVqEsbGspsQnynVpY)).

Also fixed a spelling mistake for "snaphash".