### PR TITLE
Add documentation for Player.js compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,24 @@ Third-Party:
 | Key    | Value                 | Explanation                               |
 |--------|-----------------------|-------------------------------------------|
 | loop   | `true` / `false`      | Makes the video loop at the end. Currently not supported for: Twitch, Dailymotion, Instagram, LiveLeak and Facebook |
+
+## JavaScript API
+
+The embedded player can be controlled using JavaScript in compliance with the [Player.js specification](https://github.com/embedly/player.js/blob/master/SPEC.rst). You can use [Player.js](https://github.com/embedly/player.js#playerjs) as a library to control the player.
+
+Simply load the Player.js library:
+```html
+<script type="text/javascript" src="//cdn.embed.ly/player-0.1.0.min.js"></script>
+```
+
+After this you can initialize the library using the ID of the iframe:
+
+```javascript
+const player = new playerjs.Player('your-iframe');
+```
+
+You can then call a variety of methods suchs as `player.play()` or `player.setVolume(20)`.
+
+For a full list of methods see: https://github.com/embedly/player.js#methods
+
+For a full list of events see: https://github.com/embedly/player.js#events


### PR DESCRIPTION
I've noticed there being no mention of ways to control this player in compliance with the Player.js specification ([See javascripts/player.js at line 463](https://github.com/dtube/embed/blob/master/javascripts/player.js#L463)). The changes from this pull request will allow developers to easily discover this functionality.

This pull request contains an updated README.md containing documentation on how to easily control the embed player using JavaScript.

If there are any questions, feel free to comment down below or message me on Discord under `Unkn0wnCat#8216`.